### PR TITLE
build(node): set engine version to 16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "main": "dist/index.js",
   "type": "module",
+  "engines": {
+    "node": "16.x"
+  },
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --pretty --sourceMap --watch",


### PR DESCRIPTION
Avoid having a default node version set
